### PR TITLE
Fix Bluetooth cleanup receiver unregistration

### DIFF
--- a/app/src/main/java/htl/steyr/wechselgeldapp/Bluetooth/Bluetooth.java
+++ b/app/src/main/java/htl/steyr/wechselgeldapp/Bluetooth/Bluetooth.java
@@ -142,8 +142,8 @@ package htl.steyr.wechselgeldapp.Bluetooth;
             try {
                 stopScan();
                 context.unregisterReceiver(receiver);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            } catch (IllegalArgumentException e) {
+                // Receiver was not registered. Ignore to avoid crashing.
             }
         }
     }


### PR DESCRIPTION
## Summary
- handle `cleanup` when Bluetooth receiver was never registered

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68774948f224833092a6ba5534e73fc3