### PR TITLE
Implement bluetooth demo data transfer

### DIFF
--- a/app/src/main/java/htl/steyr/wechselgeldapp/Bluetooth/BluetoothManager.java
+++ b/app/src/main/java/htl/steyr/wechselgeldapp/Bluetooth/BluetoothManager.java
@@ -1,0 +1,15 @@
+package htl.steyr.wechselgeldapp.Bluetooth;
+
+public class BluetoothManager {
+    private static Bluetooth instance;
+
+    private BluetoothManager() {}
+
+    public static void setInstance(Bluetooth bluetooth) {
+        instance = bluetooth;
+    }
+
+    public static Bluetooth getInstance() {
+        return instance;
+    }
+}

--- a/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Customer/ConnectFragment.java
+++ b/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Customer/ConnectFragment.java
@@ -84,6 +84,7 @@ public class ConnectFragment extends BaseFragment implements Bluetooth.Bluetooth
      */
     private void initializeBluetooth() {
         if (bluetooth.init()) {
+            bluetooth.startServer();
             statusText.setText("Bereit zum Scannen");
             scanButton.setEnabled(true);
         } else {
@@ -164,17 +165,31 @@ public class ConnectFragment extends BaseFragment implements Bluetooth.Bluetooth
 
     @Override
     public void onConnectionSuccess(BluetoothDevice device) {
-
+        requireActivity().runOnUiThread(() ->
+                Toast.makeText(requireContext(), "Verbunden mit " + device.getName(), Toast.LENGTH_SHORT).show());
     }
 
     @Override
     public void onDataSent(boolean success) {
+        requireActivity().runOnUiThread(() ->
+                Toast.makeText(requireContext(), success ? "Gesendet" : "Sendefehler", Toast.LENGTH_SHORT).show());
+    }
 
+    @Override
+    public void onDataReceived(UserData data) {
+        requireActivity().runOnUiThread(() -> {
+            new androidx.appcompat.app.AlertDialog.Builder(requireContext())
+                    .setTitle("Daten empfangen")
+                    .setMessage("Name: " + data.getUsername() + "\nGuthaben: " + data.getTotalAmount())
+                    .setPositiveButton("OK", null)
+                    .show();
+        });
     }
 
     @Override
     public void onDisconnected() {
-
+        requireActivity().runOnUiThread(() ->
+                Toast.makeText(requireContext(), "Verbindung getrennt", Toast.LENGTH_SHORT).show());
     }
 
     /**

--- a/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Seller/BluetoothDevicesFragment.java
+++ b/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Seller/BluetoothDevicesFragment.java
@@ -23,6 +23,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import htl.steyr.wechselgeldapp.Bluetooth.Bluetooth;
+import htl.steyr.wechselgeldapp.Bluetooth.BluetoothManager;
+import htl.steyr.wechselgeldapp.Backup.UserData;
 import htl.steyr.wechselgeldapp.R;
 
 import java.util.ArrayList;
@@ -71,6 +73,7 @@ public class BluetoothDevicesFragment extends Fragment implements Bluetooth.Blue
 
     private void setupBluetooth() {
         bluetooth = new Bluetooth(getContext(), this);
+        BluetoothManager.setInstance(bluetooth);
         if (!bluetooth.init()) {
             Toast.makeText(getContext(), "Bluetooth-Initialisierung fehlgeschlagen", Toast.LENGTH_SHORT).show();
         }
@@ -154,6 +157,7 @@ public class BluetoothDevicesFragment extends Fragment implements Bluetooth.Blue
             if (device.getName() != null) deviceName = device.getName();
             else deviceName = "Unbekannter Kunde";
         }
+        BluetoothManager.setInstance(bluetooth);
         Toast.makeText(getContext(), "Verbunden mit Kunde: " + deviceName, Toast.LENGTH_SHORT).show();
     }
 
@@ -161,6 +165,11 @@ public class BluetoothDevicesFragment extends Fragment implements Bluetooth.Blue
     public void onDataSent(boolean success) {
         String message = success ? "Daten erfolgreich an Kunde gesendet" : "Datenübertragung an Kunde fehlgeschlagen";
         Toast.makeText(getContext(), message, Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void onDataReceived(UserData data) {
+        // not used here
     }
 
     @Override

--- a/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Seller/TransactionFragment.java
+++ b/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Seller/TransactionFragment.java
@@ -4,7 +4,11 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.EditText;
+import android.widget.Button;
+
+import htl.steyr.wechselgeldapp.Backup.UserData;
+import htl.steyr.wechselgeldapp.Bluetooth.Bluetooth;
+import htl.steyr.wechselgeldapp.Bluetooth.BluetoothManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -17,7 +21,22 @@ public class TransactionFragment extends BaseFragment {
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.seller_fragment_transactions, container, false);
+        View view = inflater.inflate(R.layout.seller_fragment_transactions, container, false);
+
+        Button sendButton = view.findViewById(R.id.btnSendPayment);
+        sendButton.setOnClickListener(v -> sendDemoData());
+
+        return view;
+    }
+
+    private void sendDemoData() {
+        Bluetooth bluetooth = BluetoothManager.getInstance();
+        if (bluetooth != null && bluetooth.isConnected()) {
+            UserData data = new UserData();
+            data.setUsername("Demo Benutzer");
+            data.setTotalAmount(42.0);
+            bluetooth.sendUserData(data);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add helper `BluetoothManager` to share bluetooth connection across fragments
- expand `Bluetooth` class with server mode and data reception
- show received info in customer connect fragment
- share bluetooth instance from seller device fragment
- send demo data from seller transaction fragment

## Testing
- `./gradlew assembleDebug` *(fails: HTTP 403 when attempting to download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_68774f3e312c8330bba792db7450504a