### PR TITLE
Enable profile persistence

### DIFF
--- a/app/src/main/java/htl/steyr/wechselgeldapp/Database/DatabaseHelper.java
+++ b/app/src/main/java/htl/steyr/wechselgeldapp/Database/DatabaseHelper.java
@@ -468,6 +468,41 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         db.execSQL("INSERT INTO PersonalInformation (seller_id, name, email, street, houseNumber, zipCode, city) VALUES " + "(1, 'Admin Verkäufer', 'admin@seller.com', 'Adminstraße', '1A', '1010', 'Wien')," + "(2, 'Maier Bäcker', 'maier@shop.com', 'Brotgasse', '5', '4400', 'Steyr')," + "(3, 'Müller Kiosk', 'mueller@kiosk.com', 'Hauptstraße', '12B', '4020', 'Linz')," + "(4, 'Schmid Trafik', 'schmid@trafik.com', 'Tabakweg', '3', '5020', 'Salzburg')," + "(5, 'Huber Blumen', 'huber@flowers.com', 'Blumenweg', '7', '8010', 'Graz')," + "(6, 'Hahn Feinkost', 'hahn@finefood.com', 'Delikatessenallee', '9', '9020', 'Klagenfurt');");
     }
 
+    // ---------------- Profile SELECT/UPDATE ---------------- //
+
+    public Cursor getSellerProfile(int sellerId) {
+        SQLiteDatabase db = getReadableDatabase();
+        return db.rawQuery(
+                "SELECT s.shopName, s.email, p.street, p.houseNumber, p.zipCode, p.city " +
+                        "FROM Seller s LEFT JOIN PersonalInformation p ON s.id = p.seller_id WHERE s.id = ?",
+                new String[]{String.valueOf(sellerId)}
+        );
+    }
+
+    public Cursor getCustomerProfile(int customerId) {
+        SQLiteDatabase db = getReadableDatabase();
+        return db.rawQuery(
+                "SELECT displayName, email FROM Customer WHERE id = ?",
+                new String[]{String.valueOf(customerId)}
+        );
+    }
+
+    public int updateSellerProfile(int sellerId, String shopName, String email) {
+        SQLiteDatabase db = this.getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put("shopName", shopName);
+        values.put("email", email);
+        return db.update("Seller", values, "id = ?", new String[]{String.valueOf(sellerId)});
+    }
+
+    public int updateCustomerProfile(int customerId, String displayName, String email) {
+        SQLiteDatabase db = this.getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put("displayName", displayName);
+        values.put("email", email);
+        return db.update("Customer", values, "id = ?", new String[]{String.valueOf(customerId)});
+    }
+
 
 }
 

--- a/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Customer/ProfileFragment.java
+++ b/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Customer/ProfileFragment.java
@@ -4,17 +4,26 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.database.Cursor;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import htl.steyr.wechselgeldapp.R;
 import htl.steyr.wechselgeldapp.UI.Fragments.BaseFragment;
+import htl.steyr.wechselgeldapp.Database.DatabaseHelper;
+import htl.steyr.wechselgeldapp.Utilities.Security.SessionManager;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textfield.TextInputEditText;
 
 public class ProfileFragment extends BaseFragment {
 
+    private DatabaseHelper db;
+    private TextInputEditText etName, etEmail;
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        db = new DatabaseHelper(requireContext());
         return inflater.inflate(R.layout.customer_fragment_profile, container, false);
     }
 
@@ -22,6 +31,38 @@ public class ProfileFragment extends BaseFragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        etName = view.findViewById(R.id.et_name);
+        etEmail = view.findViewById(R.id.et_email);
+        MaterialButton saveButton = view.findViewById(R.id.btn_save);
+
+        int customerId = SessionManager.getCurrentUserId(requireContext());
+        if (customerId != -1) {
+            loadCustomerProfile(customerId);
+
+            saveButton.setOnClickListener(v -> {
+                String name = etName.getText().toString();
+                String email = etEmail.getText().toString();
+                db.updateCustomerProfile(customerId, name, email);
+            });
+        }
+    }
+
+    private void loadCustomerProfile(int customerId) {
+        Cursor cursor = db.getCustomerProfile(customerId);
+        if (cursor.moveToFirst()) {
+            etName.setText(cursor.getString(cursor.getColumnIndexOrThrow("displayName")));
+            etEmail.setText(cursor.getString(cursor.getColumnIndexOrThrow("email")));
+        }
+        cursor.close();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (db != null) {
+            db.close();
+        }
     }
 
     @Override

--- a/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Seller/ProfileFragment.java
+++ b/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Seller/ProfileFragment.java
@@ -1,7 +1,8 @@
 package htl.steyr.wechselgeldapp.UI.Fragments.Seller;
 
 import android.content.Context;
-import android.content.SharedPreferences;
+import android.database.Cursor;
+import htl.steyr.wechselgeldapp.Utilities.Security.SessionManager;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -45,11 +46,35 @@ public class ProfileFragment extends Fragment {
         city = view.findViewById(R.id.et_city);
         MaterialButton saveChanges = view.findViewById(R.id.btn_save);
 
-        // Load seller name from shared preferences
-        SharedPreferences prefs = requireContext().getSharedPreferences("user_prefs", Context.MODE_PRIVATE);
-        String shopName = prefs.getString("user_display_name",null);
+        int sellerId = SessionManager.getCurrentUserId(requireContext());
+        if (sellerId != -1) {
+            loadSellerProfile(sellerId);
 
-        name.setText(shopName);
+            saveChanges.setOnClickListener(v -> {
+                String shop = name.getText().toString();
+                String mail = email.getText().toString();
+                String str = street.getText().toString();
+                String hNr = houseNumber.getText().toString();
+                String plz = zip.getText().toString();
+                String stadt = city.getText().toString();
+
+                db.updateSellerProfile(sellerId, shop, mail);
+                db.updatePersonalInfo(sellerId, shop, mail, str, hNr, plz, stadt);
+            });
+        }
+    }
+
+    private void loadSellerProfile(int sellerId) {
+        Cursor cursor = db.getSellerProfile(sellerId);
+        if (cursor.moveToFirst()) {
+            name.setText(cursor.getString(cursor.getColumnIndexOrThrow("shopName")));
+            email.setText(cursor.getString(cursor.getColumnIndexOrThrow("email")));
+            street.setText(cursor.getString(cursor.getColumnIndexOrThrow("street")));
+            houseNumber.setText(cursor.getString(cursor.getColumnIndexOrThrow("houseNumber")));
+            zip.setText(cursor.getString(cursor.getColumnIndexOrThrow("zipCode")));
+            city.setText(cursor.getString(cursor.getColumnIndexOrThrow("city")));
+        }
+        cursor.close();
     }
 
 


### PR DESCRIPTION
## Summary
- load seller and customer data from the database
- allow saving updated profile information
- provide database helper queries and update methods

## Testing
- `./gradlew assembleDebug` *(fails: HTTP 403 during Gradle wrapper download)*

------
https://chatgpt.com/codex/tasks/task_e_688098264ae48330a695ce8619109fe0