### PR TITLE
Enable profile persistence

### DIFF
--- a/app/src/main/java/htl/steyr/wechselgeldapp/Database/DatabaseHelper.java
+++ b/app/src/main/java/htl/steyr/wechselgeldapp/Database/DatabaseHelper.java
@@ -468,6 +468,89 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         db.execSQL("INSERT INTO PersonalInformation (seller_id, name, email, street, houseNumber, zipCode, city) VALUES " + "(1, 'Admin Verkäufer', 'admin@seller.com', 'Adminstraße', '1A', '1010', 'Wien')," + "(2, 'Maier Bäcker', 'maier@shop.com', 'Brotgasse', '5', '4400', 'Steyr')," + "(3, 'Müller Kiosk', 'mueller@kiosk.com', 'Hauptstraße', '12B', '4020', 'Linz')," + "(4, 'Schmid Trafik', 'schmid@trafik.com', 'Tabakweg', '3', '5020', 'Salzburg')," + "(5, 'Huber Blumen', 'huber@flowers.com', 'Blumenweg', '7', '8010', 'Graz')," + "(6, 'Hahn Feinkost', 'hahn@finefood.com', 'Delikatessenallee', '9', '9020', 'Klagenfurt');");
     }
 
+    // ---------------- Profile SELECT/UPDATE ---------------- //
+
+    public Cursor getSellerProfile(int sellerId) {
+        SQLiteDatabase db = getReadableDatabase();
+        return db.rawQuery(
+                "SELECT s.shopName, s.email, p.street, p.houseNumber, p.zipCode, p.city " +
+                        "FROM Seller s LEFT JOIN PersonalInformation p ON s.id = p.seller_id WHERE s.id = ?",
+                new String[]{String.valueOf(sellerId)}
+        );
+    }
+
+    public Cursor getCustomerProfile(int customerId) {
+        SQLiteDatabase db = getReadableDatabase();
+        return db.rawQuery(
+                "SELECT displayName, email FROM Customer WHERE id = ?",
+                new String[]{String.valueOf(customerId)}
+        );
+    }
+
+    public int updateSellerProfile(int sellerId, String shopName, String email) {
+        SQLiteDatabase db = this.getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put("shopName", shopName);
+        values.put("email", email);
+        return db.update("Seller", values, "id = ?", new String[]{String.valueOf(sellerId)});
+    }
+
+    public int updateCustomerProfile(int customerId, String displayName, String email) {
+        SQLiteDatabase db = this.getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put("displayName", displayName);
+        values.put("email", email);
+        return db.update("Customer", values, "id = ?", new String[]{String.valueOf(customerId)});
+    }
+
+    /**
+     * Returns the password hash for a seller by their id.
+     */
+    public String getSellerPasswordHashById(int sellerId) {
+        SQLiteDatabase db = this.getReadableDatabase();
+        Cursor cursor = db.rawQuery("SELECT passwordHash FROM Seller WHERE id = ?", new String[]{String.valueOf(sellerId)});
+        String hash = null;
+        if (cursor.moveToFirst()) {
+            hash = cursor.getString(0);
+        }
+        cursor.close();
+        return hash;
+    }
+
+    /**
+     * Returns the password hash for a customer by their id.
+     */
+    public String getCustomerPasswordHashById(int customerId) {
+        SQLiteDatabase db = this.getReadableDatabase();
+        Cursor cursor = db.rawQuery("SELECT passwordHash FROM Customer WHERE id = ?", new String[]{String.valueOf(customerId)});
+        String hash = null;
+        if (cursor.moveToFirst()) {
+            hash = cursor.getString(0);
+        }
+        cursor.close();
+        return hash;
+    }
+
+    /**
+     * Updates the password for a seller.
+     */
+    public int updateSellerPassword(int sellerId, String newHash) {
+        SQLiteDatabase db = this.getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put("passwordHash", newHash);
+        return db.update("Seller", values, "id = ?", new String[]{String.valueOf(sellerId)});
+    }
+
+    /**
+     * Updates the password for a customer.
+     */
+    public int updateCustomerPassword(int customerId, String newHash) {
+        SQLiteDatabase db = this.getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put("passwordHash", newHash);
+        return db.update("Customer", values, "id = ?", new String[]{String.valueOf(customerId)});
+    }
+
 
 }
 

--- a/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Customer/ProfileFragment.java
+++ b/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Customer/ProfileFragment.java
@@ -4,17 +4,29 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.database.Cursor;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import htl.steyr.wechselgeldapp.R;
 import htl.steyr.wechselgeldapp.UI.Fragments.BaseFragment;
+import htl.steyr.wechselgeldapp.Database.DatabaseHelper;
+import htl.steyr.wechselgeldapp.Utilities.Security.SessionManager;
+import htl.steyr.wechselgeldapp.Utilities.Security.SecureData;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.textfield.TextInputEditText;
+import android.widget.Toast;
 
 public class ProfileFragment extends BaseFragment {
 
+    private DatabaseHelper db;
+    private TextInputEditText etName, etEmail;
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        db = new DatabaseHelper(requireContext());
         return inflater.inflate(R.layout.customer_fragment_profile, container, false);
     }
 
@@ -22,6 +34,79 @@ public class ProfileFragment extends BaseFragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        etName = view.findViewById(R.id.et_name);
+        etEmail = view.findViewById(R.id.et_email);
+        MaterialButton saveButton = view.findViewById(R.id.btn_save);
+        MaterialButton changePassword = view.findViewById(R.id.btn_change_password);
+
+        int customerId = SessionManager.getCurrentUserId(requireContext());
+        if (customerId != -1) {
+            loadCustomerProfile(customerId);
+
+            saveButton.setOnClickListener(v -> {
+                String name = etName.getText().toString();
+                String email = etEmail.getText().toString();
+                db.updateCustomerProfile(customerId, name, email);
+            });
+
+            changePassword.setOnClickListener(v -> showChangePasswordDialog(customerId));
+        }
+    }
+
+    private void loadCustomerProfile(int customerId) {
+        Cursor cursor = db.getCustomerProfile(customerId);
+        if (cursor.moveToFirst()) {
+            etName.setText(cursor.getString(cursor.getColumnIndexOrThrow("displayName")));
+            etEmail.setText(cursor.getString(cursor.getColumnIndexOrThrow("email")));
+        }
+        cursor.close();
+    }
+
+    private void showChangePasswordDialog(int customerId) {
+        View dialogView = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_change_password, null);
+        TextInputEditText oldPw = dialogView.findViewById(R.id.et_old_password);
+        TextInputEditText newPw = dialogView.findViewById(R.id.et_new_password);
+        TextInputEditText confirmPw = dialogView.findViewById(R.id.et_confirm_password);
+
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle("Passwort ändern")
+                .setView(dialogView)
+                .setPositiveButton("Speichern", (d, w) -> {
+                    String oldPass = oldPw.getText().toString();
+                    String newPass = newPw.getText().toString();
+                    String confirmPass = confirmPw.getText().toString();
+
+                    if (oldPass.isEmpty() || newPass.isEmpty() || confirmPass.isEmpty()) {
+                        Toast.makeText(requireContext(), "Bitte alle Felder ausfüllen", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    if (!newPass.equals(confirmPass)) {
+                        Toast.makeText(requireContext(), "Neue Passwörter stimmen nicht überein", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    String storedHash = db.getCustomerPasswordHashById(customerId);
+                    if (storedHash == null || !SecureData.checkPassword(oldPass, storedHash)) {
+                        Toast.makeText(requireContext(), "Altes Passwort falsch", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    String newHash = SecureData.hashPasswordViaBCrypt(newPass);
+                    db.updateCustomerPassword(customerId, newHash);
+                    Toast.makeText(requireContext(), "Passwort geändert", Toast.LENGTH_SHORT).show();
+                })
+                .setNegativeButton("Abbrechen", null)
+                .show();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (db != null) {
+            db.close();
+        }
     }
 
     @Override

--- a/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Seller/ProfileFragment.java
+++ b/app/src/main/java/htl/steyr/wechselgeldapp/UI/Fragments/Seller/ProfileFragment.java
@@ -1,7 +1,10 @@
 package htl.steyr.wechselgeldapp.UI.Fragments.Seller;
 
-import android.content.Context;
-import android.content.SharedPreferences;
+import android.database.Cursor;
+import htl.steyr.wechselgeldapp.Utilities.Security.SessionManager;
+import htl.steyr.wechselgeldapp.Utilities.Security.SecureData;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.widget.Toast;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -44,12 +47,77 @@ public class ProfileFragment extends Fragment {
         zip = view.findViewById(R.id.et_zip);
         city = view.findViewById(R.id.et_city);
         MaterialButton saveChanges = view.findViewById(R.id.btn_save);
+        MaterialButton changePassword = view.findViewById(R.id.btn_change_password);
 
-        // Load seller name from shared preferences
-        SharedPreferences prefs = requireContext().getSharedPreferences("user_prefs", Context.MODE_PRIVATE);
-        String shopName = prefs.getString("user_display_name",null);
+        int sellerId = SessionManager.getCurrentUserId(requireContext());
+        if (sellerId != -1) {
+            loadSellerProfile(sellerId);
 
-        name.setText(shopName);
+            saveChanges.setOnClickListener(v -> {
+                String shop = name.getText().toString();
+                String mail = email.getText().toString();
+                String str = street.getText().toString();
+                String hNr = houseNumber.getText().toString();
+                String plz = zip.getText().toString();
+                String stadt = city.getText().toString();
+
+                db.updateSellerProfile(sellerId, shop, mail);
+                db.updatePersonalInfo(sellerId, shop, mail, str, hNr, plz, stadt);
+            });
+
+            changePassword.setOnClickListener(v -> showChangePasswordDialog(sellerId));
+        }
+    }
+
+    private void loadSellerProfile(int sellerId) {
+        Cursor cursor = db.getSellerProfile(sellerId);
+        if (cursor.moveToFirst()) {
+            name.setText(cursor.getString(cursor.getColumnIndexOrThrow("shopName")));
+            email.setText(cursor.getString(cursor.getColumnIndexOrThrow("email")));
+            street.setText(cursor.getString(cursor.getColumnIndexOrThrow("street")));
+            houseNumber.setText(cursor.getString(cursor.getColumnIndexOrThrow("houseNumber")));
+            zip.setText(cursor.getString(cursor.getColumnIndexOrThrow("zipCode")));
+            city.setText(cursor.getString(cursor.getColumnIndexOrThrow("city")));
+        }
+        cursor.close();
+    }
+
+    private void showChangePasswordDialog(int sellerId) {
+        View dialogView = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_change_password, null);
+        TextInputEditText oldPw = dialogView.findViewById(R.id.et_old_password);
+        TextInputEditText newPw = dialogView.findViewById(R.id.et_new_password);
+        TextInputEditText confirmPw = dialogView.findViewById(R.id.et_confirm_password);
+
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle("Passwort ändern")
+                .setView(dialogView)
+                .setPositiveButton("Speichern", (d, w) -> {
+                    String oldPass = oldPw.getText().toString();
+                    String newPass = newPw.getText().toString();
+                    String confirmPass = confirmPw.getText().toString();
+
+                    if (oldPass.isEmpty() || newPass.isEmpty() || confirmPass.isEmpty()) {
+                        Toast.makeText(requireContext(), "Bitte alle Felder ausfüllen", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    if (!newPass.equals(confirmPass)) {
+                        Toast.makeText(requireContext(), "Neue Passwörter stimmen nicht überein", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    String storedHash = db.getSellerPasswordHashById(sellerId);
+                    if (storedHash == null || !SecureData.checkPassword(oldPass, storedHash)) {
+                        Toast.makeText(requireContext(), "Altes Passwort falsch", Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    String newHash = SecureData.hashPasswordViaBCrypt(newPass);
+                    db.updateSellerPassword(sellerId, newHash);
+                    Toast.makeText(requireContext(), "Passwort geändert", Toast.LENGTH_SHORT).show();
+                })
+                .setNegativeButton("Abbrechen", null)
+                .show();
     }
 
 

--- a/app/src/main/res/layout/dialog_change_password.xml
+++ b/app/src/main/res/layout/dialog_change_password.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Aktuelles Passwort"
+        app:boxStrokeColor="#BDBDBD">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_old_password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword"/>
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:hint="Neues Passwort"
+        app:boxStrokeColor="#BDBDBD">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_new_password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword"/>
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:hint="Neues Passwort bestätigen"
+        app:boxStrokeColor="#BDBDBD">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_confirm_password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword"/>
+    </com.google.android.material.textfield.TextInputLayout>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- load seller and customer data from the database
- allow saving updated profile information
- provide database helper queries and update methods
- add dialog for changing passwords with verification

## Testing
- `./gradlew assembleDebug` *(fails: HTTP 403 during Gradle wrapper download)*

------
https://chatgpt.com/codex/tasks/task_e_688098264ae48330a695ce8619109fe0